### PR TITLE
feat: CI 파이프라인 + API Rate Limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  lint-typecheck-build:
+    name: Lint, Typecheck & Build
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: study
+          POSTGRES_PASSWORD: study1234
+          POSTGRES_DB: good_hospital
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U study"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://study:study1234@localhost:5432/good_hospital
+      NEXT_PUBLIC_KAKAO_MAP_KEY: test_key
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma Client
+        run: pnpm exec prisma generate
+
+      - name: Run migrations
+        run: pnpm exec prisma migrate deploy
+
+      - name: Lint
+        run: pnpm exec next lint
+
+      - name: Build
+        run: pnpm exec next build

--- a/src/app/api/hospitals/[id]/reviews/route.ts
+++ b/src/app/api/hospitals/[id]/reviews/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { getReviews, createReview } from "@/services/review";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function GET(
   request: NextRequest,
@@ -35,6 +36,19 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
+
+    const ip = getClientIp(request);
+    const { success } = rateLimit(`review:${ip}`, {
+      windowMs: 60_000,
+      max: 10,
+    });
+    if (!success) {
+      return Response.json(
+        { error: "Too many requests. Please try again later." },
+        { status: 429 }
+      );
+    }
+
     const body = await request.json();
 
     if (!body.rating || typeof body.rating !== "number") {

--- a/src/app/api/recommendations/route.ts
+++ b/src/app/api/recommendations/route.ts
@@ -1,8 +1,21 @@
 import type { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
   try {
+    const ip = getClientIp(request);
+    const { success } = rateLimit(`recommendation:${ip}`, {
+      windowMs: 60_000,
+      max: 5,
+    });
+    if (!success) {
+      return Response.json(
+        { error: "Too many requests. Please try again later." },
+        { status: 429 }
+      );
+    }
+
     const body = await request.json();
 
     const { hospitalName, address, category, reason } = body;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,33 @@
+const rateMap = new Map<string, { count: number; resetTime: number }>();
+
+interface RateLimitOptions {
+  windowMs: number;
+  max: number;
+}
+
+export function rateLimit(
+  key: string,
+  options: RateLimitOptions = { windowMs: 60_000, max: 60 }
+): { success: boolean; remaining: number } {
+  const now = Date.now();
+  const entry = rateMap.get(key);
+
+  if (!entry || now > entry.resetTime) {
+    rateMap.set(key, { count: 1, resetTime: now + options.windowMs });
+    return { success: true, remaining: options.max - 1 };
+  }
+
+  entry.count++;
+
+  if (entry.count > options.max) {
+    return { success: false, remaining: 0 };
+  }
+
+  return { success: true, remaining: options.max - entry.count };
+}
+
+export function getClientIp(request: Request): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return "unknown";
+}


### PR DESCRIPTION
## Summary
- GitHub Actions CI 워크플로우 추가 (lint → typecheck → build, PostgreSQL 서비스 컨테이너)
- API Rate Limiting 미들웨어 추가 (쓰기 API 보호)
  - `POST /api/recommendations`: IP당 5회/분
  - `POST /api/hospitals/[id]/reviews`: IP당 10회/분

## Closes
- Closes #2
- Closes #4

## Test plan
- [x] `pnpm exec next build` 성공
- [x] Rate limiter 유닛 로직 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)