### PR TITLE
feat: HIRA 공공데이터 API 연동 서비스 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "fetch-hira": "tsx scripts/fetch-hira.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.19.2",

--- a/scripts/fetch-hira.ts
+++ b/scripts/fetch-hira.ts
@@ -1,0 +1,204 @@
+import "dotenv/config";
+import { PrismaClient } from "../src/generated/prisma/client.js";
+
+const prisma = new PrismaClient();
+
+const HIRA_BASE_URL = "https://apis.data.go.kr/B551182";
+const SERVICE_KEY = process.env.HIRA_API_KEY ?? "";
+const DELAY_MS = 300; // rate limit: ~3 req/sec
+
+interface HiraResponse<T> {
+  response: {
+    header: { resultCode: string; resultMsg: string };
+    body: {
+      items: { item: T | T[] } | "";
+      totalCount: number;
+    };
+  };
+}
+
+interface HospInfoItem {
+  ykiho: string;
+  yadmNm: string;
+  drTotCnt: number;
+  sdrCnt: number;
+}
+
+interface EvalItem {
+  ykiho: string;
+  yadmNm: string;
+  antiRate?: string;
+  injRate?: string;
+  mdcinCnt?: string;
+}
+
+function normalizeItems<T>(items: { item: T | T[] } | ""): T[] {
+  if (items === "" || !items) return [];
+  const item = items.item;
+  return Array.isArray(item) ? item : [item];
+}
+
+function gradeFromString(value: string | undefined): number | null {
+  if (!value) return null;
+  const num = parseInt(value, 10);
+  return isNaN(num) ? null : Math.min(5, Math.max(1, num));
+}
+
+function calculateOverallGrade(...grades: (number | null)[]): number | null {
+  const valid = grades.filter((g): g is number => g !== null);
+  if (valid.length === 0) return null;
+  return Math.round(valid.reduce((a, b) => a + b, 0) / valid.length);
+}
+
+async function fetchJson<T>(path: string, ykiho: string): Promise<T[]> {
+  const url = new URL(`${HIRA_BASE_URL}/${path}`);
+  url.searchParams.set("serviceKey", SERVICE_KEY);
+  url.searchParams.set("_type", "json");
+  url.searchParams.set("numOfRows", "10");
+  url.searchParams.set("pageNo", "1");
+  url.searchParams.set("ykiho", ykiho);
+
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const data: HiraResponse<T> = await res.json();
+  if (data.response.header.resultCode !== "00") {
+    throw new Error(`HIRA: ${data.response.header.resultMsg}`);
+  }
+  return normalizeItems(data.response.body.items);
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  if (!SERVICE_KEY) {
+    console.error("HIRA_API_KEY is not set. Add it to .env");
+    process.exit(1);
+  }
+
+  const hospitals = await prisma.hospital.findMany({
+    where: { ykiho: { not: null } },
+    select: { id: true, name: true, ykiho: true },
+  });
+
+  console.log(`Found ${hospitals.length} hospitals with ykiho\n`);
+
+  let infoUpdated = 0;
+  let evalUpdated = 0;
+  let errors = 0;
+
+  for (const hospital of hospitals) {
+    const ykiho = hospital.ykiho!;
+    process.stdout.write(`[${hospital.name}] (${ykiho}) ... `);
+
+    try {
+      // 1. Hospital info (doctor count)
+      const infoItems = await fetchJson<HospInfoItem>(
+        "hospInfoServicev2/getHospBasisList",
+        ykiho
+      );
+      if (infoItems.length > 0) {
+        const info = infoItems[0];
+        await prisma.hospital.update({
+          where: { id: hospital.id },
+          data: {
+            doctorCount: info.drTotCnt ?? 0,
+            specialistCount: info.sdrCnt ?? 0,
+          },
+        });
+        infoUpdated++;
+        process.stdout.write(`info OK `);
+      } else {
+        process.stdout.write(`info SKIP `);
+      }
+
+      await sleep(DELAY_MS);
+
+      // 2. Evaluation data
+      const evalItems = await fetchJson<EvalItem>(
+        "MadmDtlInfoService2/getDiagAmtInfo2",
+        ykiho
+      );
+      if (evalItems.length > 0) {
+        const item = evalItems[0];
+        const antibioticRate = gradeFromString(item.antiRate);
+        const injectionRate = gradeFromString(item.injRate);
+        const medicineCount = gradeFromString(item.mdcinCnt);
+
+        await prisma.hiraEvaluation.upsert({
+          where: { hospitalId: hospital.id },
+          update: {
+            antibioticRate,
+            injectionRate,
+            medicineCount,
+            overallGrade: calculateOverallGrade(
+              antibioticRate,
+              injectionRate,
+              medicineCount
+            ),
+            evaluationYear: new Date().getFullYear(),
+          },
+          create: {
+            hospitalId: hospital.id,
+            antibioticRate,
+            injectionRate,
+            medicineCount,
+            overallGrade: calculateOverallGrade(
+              antibioticRate,
+              injectionRate,
+              medicineCount
+            ),
+            evaluationYear: new Date().getFullYear(),
+          },
+        });
+        evalUpdated++;
+        process.stdout.write(`eval OK\n`);
+      } else {
+        process.stdout.write(`eval SKIP\n`);
+      }
+
+      await sleep(DELAY_MS);
+    } catch (err) {
+      errors++;
+      console.log(`ERROR: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  console.log(`\n--- Summary ---`);
+  console.log(`Hospital info updated: ${infoUpdated}/${hospitals.length}`);
+  console.log(`Evaluations updated:   ${evalUpdated}/${hospitals.length}`);
+  console.log(`Errors:                ${errors}`);
+
+  // Recalculate consc scores
+  console.log("\nRecalculating consc scores...");
+  const { calculateConscScore } = await import(
+    "../src/utils/data/conscScore.js"
+  );
+
+  const allHospitals = await prisma.hospital.findMany({
+    include: { reviews: true, hiraEvaluation: true },
+  });
+
+  for (const h of allHospitals) {
+    const avgRating =
+      h.reviews.length > 0
+        ? h.reviews.reduce((sum: number, r: { rating: number }) => sum + r.rating, 0) / h.reviews.length
+        : null;
+    const score = calculateConscScore(avgRating, h.hiraEvaluation?.overallGrade ?? null);
+    await prisma.hospital.update({
+      where: { id: h.id },
+      data: { conscScore: score },
+    });
+  }
+
+  console.log("Consc scores updated.");
+}
+
+main()
+  .catch((e) => {
+    console.error("Failed:", e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/hospitals/[id]/hira/route.ts
+++ b/src/app/api/hospitals/[id]/hira/route.ts
@@ -1,0 +1,38 @@
+import type { NextRequest } from "next/server";
+import { getHospitalById } from "@/services/hospital";
+import { syncAllFromHira } from "@/services/hira";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const hospital = await getHospitalById(id);
+
+    if (!hospital) {
+      return Response.json({ error: "Hospital not found" }, { status: 404 });
+    }
+
+    if (!hospital.ykiho) {
+      return Response.json(
+        { error: "Hospital has no ykiho code" },
+        { status: 400 }
+      );
+    }
+
+    const result = await syncAllFromHira(id, hospital.ykiho);
+
+    return Response.json({
+      message: "HIRA data synced",
+      hospitalId: id,
+      ...result,
+    });
+  } catch (error) {
+    console.error("POST /api/hospitals/[id]/hira error:", error);
+    return Response.json(
+      { error: "Failed to sync HIRA data" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/hira-client.ts
+++ b/src/lib/hira-client.ts
@@ -1,0 +1,183 @@
+import { env } from "@/lib/env";
+
+const HIRA_BASE_URL = "https://apis.data.go.kr/B551182";
+
+interface HiraRequestParams {
+  serviceKey: string;
+  ykiho?: string;
+  pageNo?: number;
+  numOfRows?: number;
+  _type?: string;
+  [key: string]: string | number | undefined;
+}
+
+interface HiraHospitalInfoItem {
+  ykiho: string;
+  yadmNm: string;
+  drTotCnt: number;
+  sdrCnt: number;
+}
+
+interface HiraEvalItem {
+  ykiho: string;
+  yadmNm: string;
+  antiRate?: string;
+  injRate?: string;
+  mdcinCnt?: string;
+  score?: string;
+}
+
+interface HiraResponse<T> {
+  response: {
+    header: {
+      resultCode: string;
+      resultMsg: string;
+    };
+    body: {
+      items: { item: T | T[] } | "";
+      numOfRows: number;
+      pageNo: number;
+      totalCount: number;
+    };
+  };
+}
+
+export interface HospitalInfoResult {
+  ykiho: string;
+  name: string;
+  doctorCount: number;
+  specialistCount: number;
+}
+
+export interface EvaluationResult {
+  ykiho: string;
+  name: string;
+  antibioticRate: number | null;
+  injectionRate: number | null;
+  medicineCount: number | null;
+  overallGrade: number | null;
+}
+
+function gradeFromString(value: string | undefined): number | null {
+  if (!value) return null;
+  const num = parseInt(value, 10);
+  return isNaN(num) ? null : Math.min(5, Math.max(1, num));
+}
+
+function calculateOverallGrade(
+  antibioticRate: number | null,
+  injectionRate: number | null,
+  medicineCount: number | null
+): number | null {
+  const grades = [antibioticRate, injectionRate, medicineCount].filter(
+    (g): g is number => g !== null
+  );
+  if (grades.length === 0) return null;
+  return Math.round(grades.reduce((a, b) => a + b, 0) / grades.length);
+}
+
+function buildUrl(path: string, params: HiraRequestParams): string {
+  const url = new URL(`${HIRA_BASE_URL}/${path}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function normalizeItems<T>(items: { item: T | T[] } | ""): T[] {
+  if (items === "" || !items) return [];
+  const item = items.item;
+  return Array.isArray(item) ? item : [item];
+}
+
+async function fetchHira<T>(
+  path: string,
+  params: Omit<HiraRequestParams, "serviceKey" | "_type">
+): Promise<T[]> {
+  const url = buildUrl(path, {
+    serviceKey: env.HIRA_API_KEY,
+    _type: "json",
+    numOfRows: 100,
+    pageNo: 1,
+    ...params,
+  });
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HIRA API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data: HiraResponse<T> = await response.json();
+
+  if (data.response.header.resultCode !== "00") {
+    throw new Error(
+      `HIRA API error: ${data.response.header.resultCode} - ${data.response.header.resultMsg}`
+    );
+  }
+
+  return normalizeItems(data.response.body.items);
+}
+
+export async function fetchHospitalInfo(
+  ykiho: string
+): Promise<HospitalInfoResult | null> {
+  const items = await fetchHira<HiraHospitalInfoItem>(
+    "hospInfoServicev2/getHospBasisList",
+    { ykiho }
+  );
+
+  if (items.length === 0) return null;
+
+  const item = items[0];
+  return {
+    ykiho: item.ykiho,
+    name: item.yadmNm,
+    doctorCount: item.drTotCnt ?? 0,
+    specialistCount: item.sdrCnt ?? 0,
+  };
+}
+
+export async function fetchHospitalEvaluation(
+  ykiho: string
+): Promise<EvaluationResult | null> {
+  const items = await fetchHira<HiraEvalItem>(
+    "MadmDtlInfoService2/getDiagAmtInfo2",
+    { ykiho }
+  );
+
+  if (items.length === 0) return null;
+
+  const item = items[0];
+  const antibioticRate = gradeFromString(item.antiRate);
+  const injectionRate = gradeFromString(item.injRate);
+  const medicineCount = gradeFromString(item.mdcinCnt);
+
+  return {
+    ykiho: item.ykiho,
+    name: item.yadmNm,
+    antibioticRate,
+    injectionRate,
+    medicineCount,
+    overallGrade: calculateOverallGrade(antibioticRate, injectionRate, medicineCount),
+  };
+}
+
+const CACHE = new Map<string, { data: unknown; expiresAt: number }>();
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export async function cachedFetch<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttlMs: number = DEFAULT_TTL_MS
+): Promise<T> {
+  const cached = CACHE.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data as T;
+  }
+
+  const data = await fetcher();
+  CACHE.set(key, { data, expiresAt: Date.now() + ttlMs });
+  return data;
+}

--- a/src/services/hira.ts
+++ b/src/services/hira.ts
@@ -1,4 +1,9 @@
 import { prisma } from "@/lib/db";
+import {
+  fetchHospitalInfo,
+  fetchHospitalEvaluation,
+  cachedFetch,
+} from "@/lib/hira-client";
 import type { HiraEvaluation } from "@/generated/prisma/client";
 
 export async function getHiraEvaluation(
@@ -18,4 +23,66 @@ export async function getHiraEvaluationByYkiho(
   });
 
   return hospital?.hiraEvaluation ?? null;
+}
+
+export async function syncHospitalFromHira(
+  hospitalId: string,
+  ykiho: string
+): Promise<{ doctorCount: number; specialistCount: number } | null> {
+  const info = await cachedFetch(`hospital-info:${ykiho}`, () =>
+    fetchHospitalInfo(ykiho)
+  );
+
+  if (!info) return null;
+
+  await prisma.hospital.update({
+    where: { id: hospitalId },
+    data: {
+      doctorCount: info.doctorCount,
+      specialistCount: info.specialistCount,
+    },
+  });
+
+  return {
+    doctorCount: info.doctorCount,
+    specialistCount: info.specialistCount,
+  };
+}
+
+export async function syncEvaluationFromHira(
+  hospitalId: string,
+  ykiho: string
+): Promise<HiraEvaluation | null> {
+  const evaluation = await cachedFetch(`evaluation:${ykiho}`, () =>
+    fetchHospitalEvaluation(ykiho)
+  );
+
+  if (!evaluation) return null;
+
+  return prisma.hiraEvaluation.upsert({
+    where: { hospitalId },
+    update: {
+      antibioticRate: evaluation.antibioticRate,
+      injectionRate: evaluation.injectionRate,
+      medicineCount: evaluation.medicineCount,
+      overallGrade: evaluation.overallGrade,
+      evaluationYear: new Date().getFullYear(),
+    },
+    create: {
+      hospitalId,
+      antibioticRate: evaluation.antibioticRate,
+      injectionRate: evaluation.injectionRate,
+      medicineCount: evaluation.medicineCount,
+      overallGrade: evaluation.overallGrade,
+      evaluationYear: new Date().getFullYear(),
+    },
+  });
+}
+
+export async function syncAllFromHira(hospitalId: string, ykiho: string) {
+  const [info, evaluation] = await Promise.all([
+    syncHospitalFromHira(hospitalId, ykiho),
+    syncEvaluationFromHira(hospitalId, ykiho),
+  ]);
+  return { info, evaluation };
 }


### PR DESCRIPTION
## Summary
- HIRA 병원정보서비스 + 병원평가정보서비스 API 클라이언트 구현
- ykiho 기반 병원 매칭 및 DB 동기화 서비스 레이어 추가
- 전체 병원 일괄 수집 스크립트 (`npm run fetch-hira`)
- 인메모리 캐싱으로 API 과다 호출 방지
- `POST /api/hospitals/:id/hira` 단건 동기화 엔드포인트

Closes #11

## Test plan
- [ ] `.env`에 `HIRA_API_KEY` 설정 후 `npm run fetch-hira` 실행
- [ ] `POST /api/hospitals/:id/hira` 호출하여 단건 동기화 확인
- [ ] ykiho 없는 병원에 대해 400 응답 확인
- [ ] 존재하지 않는 hospital ID에 대해 404 응답 확인