### PR TITLE
feat: SEO 최적화 및 메타데이터

### DIFF
--- a/src/app/hospital/[id]/HospitalDetail.tsx
+++ b/src/app/hospital/[id]/HospitalDetail.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import ConscScore from "@/components/hospital/ConscScore";
+import HiraCard from "@/components/hospital/HiraCard";
+import ReviewList from "@/components/review/ReviewList";
+import ReviewForm from "@/components/review/ReviewForm";
+
+const KakaoMap = dynamic(() => import("@/components/map/KakaoMap"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full items-center justify-center bg-gray-100 rounded-lg">
+      <p className="text-sm text-gray-500">지도를 불러오는 중...</p>
+    </div>
+  ),
+});
+
+interface ReviewItem {
+  id: string;
+  rating: number;
+  content: string | null;
+  isConsc: boolean;
+  authorName: string | null;
+  createdAt: string;
+}
+
+interface HospitalData {
+  id: string;
+  name: string;
+  address: string;
+  phone: string | null;
+  latitude: number;
+  longitude: number;
+  categoryId: string;
+  conscScore: number | null;
+  openTime: string | null;
+  closeTime: string | null;
+  description: string | null;
+  isVerified: boolean;
+  source: string;
+  category: { id: string; name: string; slug: string };
+  hiraEvaluation: {
+    antibioticRate: number | null;
+    injectionRate: number | null;
+    medicineCount: number | null;
+    overallGrade: number | null;
+    evaluationYear: number;
+  } | null;
+  reviews: ReviewItem[];
+}
+
+export default function HospitalDetail({ hospital }: { hospital: HospitalData }) {
+  const [reviews, setReviews] = useState<ReviewItem[]>(hospital.reviews);
+
+  const handleReviewSubmitted = useCallback(async () => {
+    const res = await fetch(`/api/hospitals/${hospital.id}/reviews`);
+    if (res.ok) {
+      const result = await res.json();
+      setReviews(result.data);
+    }
+  }, [hospital.id]);
+
+  const conscCount = reviews.filter((r) => r.isConsc).length;
+  const overCount = reviews.filter((r) => !r.isConsc).length;
+
+  return (
+    <div className="mx-auto max-w-2xl p-4 pb-20">
+      {/* Back */}
+      <Link
+        href="/"
+        className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 19.5L8.25 12l7.5-7.5"
+          />
+        </svg>
+        뒤로
+      </Link>
+
+      {/* Hospital Info */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">{hospital.name}</h1>
+          <p className="mt-1 text-sm text-gray-500">{hospital.address}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+              {hospital.category.name}
+            </span>
+            {hospital.phone && (
+              <a
+                href={`tel:${hospital.phone}`}
+                className="rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-600 hover:bg-blue-100"
+              >
+                {hospital.phone}
+              </a>
+            )}
+          </div>
+          {(hospital.openTime || hospital.closeTime) && (
+            <p className="mt-2 text-xs text-gray-500">
+              진료시간: {hospital.openTime ?? "?"} ~ {hospital.closeTime ?? "?"}
+            </p>
+          )}
+        </div>
+        <ConscScore score={hospital.conscScore} size="md" />
+      </div>
+
+      {/* HIRA Card */}
+      <div className="mt-6">
+        <HiraCard evaluation={hospital.hiraEvaluation} />
+      </div>
+
+      {/* Mini Map */}
+      <div className="mt-6">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700">위치</h2>
+        <div className="h-48 overflow-hidden rounded-lg border border-gray-200">
+          <KakaoMap
+            hospitals={[
+              {
+                ...hospital,
+                _count: { reviews: reviews.length },
+                category: hospital.category,
+              },
+            ]}
+            center={{ lat: hospital.latitude, lng: hospital.longitude }}
+            level={3}
+          />
+        </div>
+        <a
+          href={`https://map.kakao.com/link/to/${encodeURIComponent(hospital.name)},${hospital.latitude},${hospital.longitude}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-green-600 hover:text-green-700"
+        >
+          길찾기
+          <svg
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+            />
+          </svg>
+        </a>
+      </div>
+
+      {/* Reviews */}
+      <div className="mt-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700">리뷰</h2>
+          <div className="flex gap-3 text-xs">
+            <span className="text-green-600">양심적 {conscCount}</span>
+            <span className="text-red-500">과잉진료 {overCount}</span>
+          </div>
+        </div>
+        <div className="mt-3">
+          <ReviewList reviews={reviews} />
+        </div>
+      </div>
+
+      {/* Review Form */}
+      <div className="mt-6 rounded-lg border border-gray-200 bg-white p-4">
+        <h2 className="mb-3 text-sm font-semibold text-gray-700">
+          리뷰 작성
+        </h2>
+        <ReviewForm
+          hospitalId={hospital.id}
+          onSubmitted={handleReviewSubmitted}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/hospital/[id]/page.tsx
+++ b/src/app/hospital/[id]/page.tsx
@@ -1,238 +1,96 @@
-"use client";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getHospitalById } from "@/services/hospital";
+import HospitalDetail from "./HospitalDetail";
 
-import { useState, useEffect, useCallback } from "react";
-import { useParams } from "next/navigation";
-import Link from "next/link";
-import dynamic from "next/dynamic";
-import ConscScore from "@/components/hospital/ConscScore";
-import HiraCard from "@/components/hospital/HiraCard";
-import ReviewList from "@/components/review/ReviewList";
-import ReviewForm from "@/components/review/ReviewForm";
-interface HospitalDetailResponse {
-  id: string;
-  name: string;
-  address: string;
-  phone: string | null;
-  latitude: number;
-  longitude: number;
-  categoryId: string;
-  conscScore: number | null;
-  openTime: string | null;
-  closeTime: string | null;
-  description: string | null;
-  isVerified: boolean;
-  source: string;
-  category: { id: string; name: string; slug: string };
-  hiraEvaluation: {
-    antibioticRate: number | null;
-    injectionRate: number | null;
-    medicineCount: number | null;
-    overallGrade: number | null;
-    evaluationYear: number;
-  } | null;
-  reviews: ReviewItem[];
+interface Props {
+  params: Promise<{ id: string }>;
 }
 
-const KakaoMap = dynamic(() => import("@/components/map/KakaoMap"), {
-  ssr: false,
-  loading: () => (
-    <div className="flex h-full items-center justify-center bg-gray-100 rounded-lg">
-      <p className="text-sm text-gray-500">지도를 불러오는 중...</p>
-    </div>
-  ),
-});
-
-interface ReviewItem {
-  id: string;
-  rating: number;
-  content: string | null;
-  isConsc: boolean;
-  authorName: string | null;
-  createdAt: string;
-}
-
-export default function HospitalDetailPage() {
-  const params = useParams<{ id: string }>();
-  const [hospital, setHospital] = useState<HospitalDetailResponse | null>(null);
-  const [reviews, setReviews] = useState<ReviewItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const fetchHospital = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/hospitals/${params.id}`);
-      if (!res.ok) throw new Error("Not found");
-      const data: HospitalDetailResponse = await res.json();
-      setHospital(data);
-      setReviews(data.reviews);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [params.id]);
-
-  useEffect(() => {
-    fetchHospital();
-  }, [fetchHospital]);
-
-  const handleReviewSubmitted = useCallback(async () => {
-    const res = await fetch(`/api/hospitals/${params.id}/reviews`);
-    if (res.ok) {
-      const result = await res.json();
-      setReviews(result.data);
-    }
-  }, [params.id]);
-
-  if (isLoading) {
-    return (
-      <div className="mx-auto max-w-2xl p-4">
-        <div className="animate-pulse space-y-4">
-          <div className="h-6 w-1/3 rounded bg-gray-200" />
-          <div className="h-4 w-2/3 rounded bg-gray-200" />
-          <div className="h-32 rounded bg-gray-200" />
-          <div className="h-48 rounded bg-gray-200" />
-        </div>
-      </div>
-    );
-  }
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const hospital = await getHospitalById(id);
 
   if (!hospital) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-4 py-20">
-        <p className="text-gray-500">병원을 찾을 수 없습니다.</p>
-        <Link
-          href="/"
-          className="text-sm font-medium text-green-600 hover:text-green-700"
-        >
-          메인으로 돌아가기
-        </Link>
-      </div>
-    );
+    return { title: "병원을 찾을 수 없습니다" };
   }
 
-  const conscCount = reviews.filter((r) => r.isConsc).length;
-  const overCount = reviews.filter((r) => !r.isConsc).length;
+  const description = `${hospital.name} - ${hospital.address}. ${hospital.category.name} 분야의 양심병원 정보, HIRA 평가, 리뷰를 확인하세요.`;
+
+  return {
+    title: hospital.name,
+    description,
+    openGraph: {
+      title: `${hospital.name} | 양심병원 지도`,
+      description,
+      type: "article",
+    },
+  };
+}
+
+export default async function HospitalDetailPage({ params }: Props) {
+  const { id } = await params;
+  const hospital = await getHospitalById(id);
+
+  if (!hospital) {
+    notFound();
+  }
+
+  const avgRating =
+    hospital.reviews.length > 0
+      ? hospital.reviews.reduce((sum, r) => sum + r.rating, 0) /
+        hospital.reviews.length
+      : undefined;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MedicalClinic",
+    name: hospital.name,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: hospital.address,
+      addressCountry: "KR",
+    },
+    ...(hospital.phone && { telephone: hospital.phone }),
+    ...(hospital.latitude &&
+      hospital.longitude && {
+        geo: {
+          "@type": "GeoCoordinates",
+          latitude: hospital.latitude,
+          longitude: hospital.longitude,
+        },
+      }),
+    ...(hospital.openTime && {
+      openingHours: `Mo-Fr ${hospital.openTime}-${hospital.closeTime ?? "18:00"}`,
+    }),
+    ...(avgRating && {
+      aggregateRating: {
+        "@type": "AggregateRating",
+        ratingValue: avgRating.toFixed(1),
+        reviewCount: hospital.reviews.length,
+        bestRating: 5,
+        worstRating: 1,
+      },
+    }),
+  };
+
+  const serialized = JSON.parse(
+    JSON.stringify({
+      ...hospital,
+      reviews: hospital.reviews.map((r) => ({
+        ...r,
+        createdAt: r.createdAt.toISOString(),
+      })),
+    })
+  );
 
   return (
-    <div className="mx-auto max-w-2xl p-4 pb-20">
-      {/* Back */}
-      <Link
-        href="/"
-        className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
-      >
-        <svg
-          className="h-4 w-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={2}
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M15.75 19.5L8.25 12l7.5-7.5"
-          />
-        </svg>
-        뒤로
-      </Link>
-
-      {/* Hospital Info */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-xl font-bold text-gray-900">{hospital.name}</h1>
-          <p className="mt-1 text-sm text-gray-500">{hospital.address}</p>
-          <div className="mt-2 flex flex-wrap gap-2">
-            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-              {hospital.category.name}
-            </span>
-            {hospital.phone && (
-              <a
-                href={`tel:${hospital.phone}`}
-                className="rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-600 hover:bg-blue-100"
-              >
-                {hospital.phone}
-              </a>
-            )}
-          </div>
-          {(hospital.openTime || hospital.closeTime) && (
-            <p className="mt-2 text-xs text-gray-500">
-              진료시간: {hospital.openTime ?? "?"} ~ {hospital.closeTime ?? "?"}
-            </p>
-          )}
-        </div>
-        <ConscScore score={hospital.conscScore} size="md" />
-      </div>
-
-      {/* HIRA Card */}
-      <div className="mt-6">
-        <HiraCard evaluation={hospital.hiraEvaluation} />
-      </div>
-
-      {/* Mini Map */}
-      <div className="mt-6">
-        <h2 className="mb-2 text-sm font-semibold text-gray-700">위치</h2>
-        <div className="h-48 overflow-hidden rounded-lg border border-gray-200">
-          <KakaoMap
-            hospitals={[
-              {
-                ...hospital,
-                _count: { reviews: reviews.length },
-                category: hospital.category,
-              },
-            ]}
-            center={{ lat: hospital.latitude, lng: hospital.longitude }}
-            level={3}
-          />
-        </div>
-        <a
-          href={`https://map.kakao.com/link/to/${encodeURIComponent(hospital.name)},${hospital.latitude},${hospital.longitude}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-green-600 hover:text-green-700"
-        >
-          길찾기
-          <svg
-            className="h-3.5 w-3.5"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
-            />
-          </svg>
-        </a>
-      </div>
-
-      {/* Reviews */}
-      <div className="mt-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-gray-700">리뷰</h2>
-          <div className="flex gap-3 text-xs">
-            <span className="text-green-600">양심적 {conscCount}</span>
-            <span className="text-red-500">과잉진료 {overCount}</span>
-          </div>
-        </div>
-        <div className="mt-3">
-          <ReviewList reviews={reviews} />
-        </div>
-      </div>
-
-      {/* Review Form */}
-      <div className="mt-6 rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="mb-3 text-sm font-semibold text-gray-700">
-          리뷰 작성
-        </h2>
-        <ReviewForm
-          hospitalId={hospital.id}
-          onSubmitted={handleReviewSubmitted}
-        />
-      </div>
-    </div>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <HospitalDetail hospital={serialized} />
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,10 +14,37 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const SITE_NAME = "양심병원 지도";
+const SITE_DESCRIPTION =
+  "과잉진료 없는 양심 병원을 지도에서 쉽게 찾아보세요. 커뮤니티 추천과 HIRA 공공데이터로 검증된 병원 정보를 제공합니다.";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://good-hospital.vercel.app";
+
 export const metadata: Metadata = {
-  title: "양심병원 지도",
-  description:
-    "과잉진료 없는 양심 병원을 지도에서 쉽게 찾아보세요. 커뮤니티 추천과 HIRA 공공데이터로 검증된 병원 정보를 제공합니다.",
+  title: {
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  metadataBase: new URL(SITE_URL),
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    locale: "ko_KR",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: SITE_URL,
+  },
 };
 
 export default function RootLayout({

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 py-20">
+      <h1 className="text-2xl font-bold text-gray-900">404</h1>
+      <p className="text-gray-500">페이지를 찾을 수 없습니다.</p>
+      <Link
+        href="/"
+        className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 transition-colors"
+      >
+        메인으로 돌아가기
+      </Link>
+    </div>
+  );
+}

--- a/src/app/recommend/page.tsx
+++ b/src/app/recommend/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import RecommendForm from "@/components/recommend/RecommendForm";
+
+export const metadata: Metadata = {
+  title: "양심 병원 제보",
+  description:
+    "과잉진료 없는 양심적인 병원을 알고 계신가요? 제보해 주시면 검토 후 등록됩니다.",
+};
 
 export default function RecommendPage() {
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://good-hospital.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,44 @@
+import type { MetadataRoute } from "next";
+import { prisma } from "@/lib/db";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://good-hospital.vercel.app";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const hospitals = await prisma.hospital.findMany({
+    select: { id: true, updatedAt: true },
+  });
+
+  const categories = await prisma.category.findMany({
+    select: { slug: true },
+  });
+
+  const hospitalEntries: MetadataRoute.Sitemap = hospitals.map((h) => ({
+    url: `${SITE_URL}/hospital/${h.id}`,
+    lastModified: h.updatedAt,
+    changeFrequency: "weekly",
+    priority: 0.8,
+  }));
+
+  const categoryEntries: MetadataRoute.Sitemap = categories.map((c) => ({
+    url: `${SITE_URL}/category/${c.slug}`,
+    changeFrequency: "weekly",
+    priority: 0.6,
+  }));
+
+  return [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/recommend`,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    ...hospitalEntries,
+    ...categoryEntries,
+  ];
+}


### PR DESCRIPTION
## Summary
- 루트 레이아웃에 OG/Twitter 메타데이터, metadataBase 설정
- 병원 상세 페이지를 서버 컴포넌트로 전환하여 동적 메타데이터 + LocalBusiness JSON-LD 추가
- `sitemap.ts`, `robots.ts` 생성 (모든 병원/카테고리 페이지 포함)
- 404 에러 페이지 추가
- 제보 페이지 메타데이터 추가

Closes #18

## Test plan
- [ ] 병원 상세 페이지 소스에서 og:title, JSON-LD 확인
- [ ] `/sitemap.xml` 접근하여 전체 URL 목록 확인
- [ ] `/robots.txt` 확인 (/api/ 차단)
- [ ] 존재하지 않는 URL에서 404 페이지 표시 확인