### PR TITLE
perf: 카카오맵 lazy loading 및 API 응답 캐싱

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -3,7 +3,11 @@ import { getCategoryTree } from "@/services/category";
 export async function GET() {
   try {
     const categories = await getCategoryTree();
-    return Response.json({ data: categories });
+    return Response.json({ data: categories }, {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
   } catch (error) {
     console.error("GET /api/categories error:", error);
     return Response.json(

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -17,7 +17,11 @@ export async function GET(request: NextRequest) {
         : undefined,
     });
 
-    return Response.json(result);
+    return Response.json(result, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      },
+    });
   } catch (error) {
     console.error("GET /api/hospitals error:", error);
     return Response.json(

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -99,7 +99,7 @@ export default function RootLayout({
         <main className="flex flex-1 flex-col">{children}</main>
         <Script
           src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&libraries=services,clusterer&autoload=false`}
-          strategy="beforeInteractive"
+          strategy="afterInteractive"
         />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- 카카오맵 SDK `strategy`를 `beforeInteractive` → `afterInteractive`로 변경 (render-blocking 제거)
- hospitals API에 `Cache-Control: s-maxage=60, stale-while-revalidate=300` 적용
- categories API에 `Cache-Control: s-maxage=3600, stale-while-revalidate=86400` 적용

Closes #19

## Test plan
- [ ] 페이지 로드 시 카카오맵 SDK가 non-blocking으로 로드되는지 확인
- [ ] API 응답 헤더에 Cache-Control이 포함되는지 확인
- [ ] 지도가 정상 렌더링되는지 확인